### PR TITLE
use the new download-api

### DIFF
--- a/npm-download-counts.js
+++ b/npm-download-counts.js
@@ -11,19 +11,14 @@ function day (s) {
   return s.toISOString().substr(0, 10)
 }
 
-
 function downloadCounts (pkg, start, end, callback) {
-  var startkey   = [ pkg, day(start) ]
-    , endkey     = [ pkg, day(end)   ]
+  var startkey   = day(start)
+    , endkey     = day(end)
     , grouplevel = 2
                    // hardwired url cause I don't think anyone bothers
                    // replicating this
-    , url        = 'http://isaacs.iriscouch.com/downloads/_design/app/_view/pkg?'
-        + qs.stringify({
-              startkey    : JSON.stringify(startkey)
-            , endkey      : JSON.stringify(endkey)
-            , group_level : grouplevel
-          })
+    , url        = 'https://api.npmjs.org/downloads/range/' +
+                      startkey + ':' + endkey + '/' + pkg
 
   hyperquest.get(url).pipe(bl(function (err, body) {
     if (err)
@@ -45,10 +40,10 @@ function downloadCounts (pkg, start, end, callback) {
           + ')'))
     }
 
-    callback(null, doc.rows.map(function (row) {
+    callback(null, doc.downloads.map(function (row) {
       return {
-          day   : row.key[1]
-        , count : row.value
+          day   : row.day
+        , count : row.downloads
       }
     }))
   }))

--- a/test.js
+++ b/test.js
@@ -3,8 +3,8 @@ const assert = require('assert')
     , downloadCounts = require('./')
 
     , pkg    = 'levelup'
-    , start  = moment().subtract('months', 1).zone(0).toDate()
-    , end    = new Date()
+    , start  = moment().subtract('months', 3).zone(0).toDate()
+    , end    = moment().subtract('months', 2).zone(0).toDate()
 
 var timer = setTimeout(function () {
       assert(false, 'didn\'t get called in good time')


### PR DESCRIPTION
Adjust the testdata, as we had a hiccup in the api

note: not really shure about the change to tests, as these will fail in 3 months now. Do you have a better idea?
